### PR TITLE
Agregado return mixed a función query

### DIFF
--- a/Conn2db.php
+++ b/Conn2db.php
@@ -67,7 +67,7 @@ class Conn2db
      * @param array  $params
      * @param string $fetchmode
      *
-     * @return void
+     * @return mixed
      **/
     public function query($sql, $params = null, $fetchmode = \PDO::FETCH_ASSOC)
     {


### PR DESCRIPTION
Se agrega el argumento mixed para el return de la función query para
evitar el error que mostraba que la función al ser usada marcaba error
al pasarlo a una variable.